### PR TITLE
增加悬浮条爆发开关与透明度

### DIFF
--- a/App/AppOptions.cs
+++ b/App/AppOptions.cs
@@ -12,7 +12,8 @@ public sealed record AppOptions(
     SendMode Mode,
     string? ModuleId,
     TimeSpan LogicInterval,
-    TimeSpan RenderInterval)
+    TimeSpan RenderInterval,
+    bool BurstAutoOff = true)
 {
     public static AppOptions FromArgs(string[] args)
     {
@@ -21,6 +22,7 @@ public sealed record AppOptions(
         string? moduleId = null;
         var logicInterval = TimeSpan.FromMilliseconds(100);
         var renderInterval = TimeSpan.FromMilliseconds(100);
+        var burstAutoOff = true;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -48,10 +50,14 @@ public sealed record AppOptions(
                     renderInterval = TimeSpan.FromMilliseconds(Math.Max(100, renderMs));
                     i++;
                     break;
+                case "--burst-auto-off" when value is not null:
+                    burstAutoOff = ParseBool(value, defaultValue: true);
+                    i++;
+                    break;
             }
         }
 
-        return new AppOptions(toggleKey, mode, moduleId, logicInterval, renderInterval);
+        return new AppOptions(toggleKey, mode, moduleId, logicInterval, renderInterval, burstAutoOff);
     }
 
     private static SendMode ParseMode(string value)
@@ -61,6 +67,16 @@ public sealed record AppOptions(
             "click" => SendMode.Click,
             "hold" => SendMode.Hold,
             _ => SendMode.Switch
+        };
+    }
+
+    private static bool ParseBool(string value, bool defaultValue)
+    {
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "1" or "true" or "yes" or "on" or "是" => true,
+            "0" or "false" or "no" or "off" or "否" => false,
+            _ => defaultValue
         };
     }
 }

--- a/App/RuntimeSessionCoordinator.cs
+++ b/App/RuntimeSessionCoordinator.cs
@@ -84,6 +84,24 @@ internal sealed class RuntimeSessionCoordinator : IAsyncDisposable
         }
     }
 
+    public void ActivateBurst()
+    {
+        var session = Volatile.Read(ref _current);
+        if (session is { RunTask.IsCompleted: false })
+        {
+            session.Runtime.ActivateBurst();
+        }
+    }
+
+    public void ToggleBurst()
+    {
+        var session = Volatile.Read(ref _current);
+        if (session is { RunTask.IsCompleted: false })
+        {
+            session.Runtime.ToggleBurst();
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
         await _lifecycleGate.WaitAsync().ConfigureAwait(false);

--- a/Infrastructure/UiCacheStore.cs
+++ b/Infrastructure/UiCacheStore.cs
@@ -64,6 +64,9 @@ internal sealed class UiCacheState
     public string? SelectedSettingsPage { get; set; }
     public string? MainWindowLayout { get; set; }
     public string? ToggleKey { get; set; }
+    public bool? BurstAutoOff { get; set; }
+    /// <summary>悬浮条不透明度，0.30～1.00；空则使用默认。</summary>
+    public double? MainBarOpacity { get; set; }
     public string? SelectedModuleId { get; set; }
     public Dictionary<string, int>? ModuleRulesGridColumns { get; set; }
 }

--- a/README.md
+++ b/README.md
@@ -44,18 +44,20 @@ Shigure 是一个 Windows WinForms 桌面程序。它从目标窗口读取 Fuyut
 
 ## 界面
 
-- 置顶浮动条：显示程序名、当前职业图标颜色和逻辑状态，提供 `开启/关闭`、`设置`、`✕` 按钮。窗口可拖动和缩放，显示后自动启动运行循环。
-- `通用`：设置触发键和发送模式；从项目 Fuyutsui 更新配置并同步游戏插件；按实时环境筛选、自动选择或手动指定模块。
+- 置顶浮动条：显示程序名、当前职业图标颜色和逻辑状态，提供 `开启/关闭`、`爆发`、`设置`、`✕` 按钮。窗口可拖动和缩放，显示后自动启动运行循环。
+- `通用`：设置触发键、发送模式、爆发自动关和悬浮条透明度；从项目 Fuyutsui 更新配置并同步游戏插件；按实时环境筛选、自动选择或手动指定模块。
 - `配置`：直接编辑项目 `Fuyutsui/class/*.lua` 中的 `ClassBlocks`，包括状态、光环、法术和队伍字段；技能列表页可编辑 `Fuyutsui.spellsList` 中索引 1–100 的法术 ID、索引和名称，也可输入 spellId 与名称并自动分配空闲索引。旧版稀疏索引格式只读，需先迁移到 `states/auras/spells/group` 格式。
 - `宏`：编辑项目 `Fuyutsui/core/classmacros.lua` 中各职业的动态宏、静态宏和特殊宏。动态宏每项占用 30 个团队点名槽位。
 - `模块`：新建、编辑、删除本地模块，维护作者、推荐天赋、匹配条件、动态字段和有序规则。规则支持拖拽、上移、下移、复制与插入。
 - `状态`：分栏显示基础状态、`auras`、`spells` 和模块计算出的动态单位/数值。
 - `队伍`：显示 `group` 中当前队伍成员及扫描字段摘要。
 - `逻辑`：显示命中模块、目标、按键和调试值。
-- `日志`：记录启动、停止、职业识别、模块匹配、逻辑状态、施放步骤、配置同步和异常。
+- `日志`：记录启动、停止、职业识别、模块匹配、逻辑状态、爆发开关、施放步骤、配置同步和异常。
 - `关于`：显示产品、公司、版本、模块目录和配置目录。
 
-触发键、发送模式、模块选择、模块保存以及配置同步都会按需重启运行循环。窗口位置、大小、主界面横纵布局（两个方向分别保存窗口位置）、模块选择和表格列宽等 UI 状态保存在我的文档目录 `{MyDocuments}/Shigure/cache/window-state.json`；模块保存在 `{MyDocuments}/Shigure/module`。`cache/` 与模块数据都是本地数据，默认不提交到 Git。
+触发键、发送模式、爆发自动关、模块选择、模块保存以及配置同步都会按需重启运行循环。窗口位置、大小、主界面横纵布局（两个方向分别保存窗口位置）、模块选择、爆发自动关、悬浮条透明度和表格列宽等 UI 状态保存在我的文档目录 `{MyDocuments}/Shigure/cache/window-state.json`；模块保存在 `{MyDocuments}/Shigure/module`。`cache/` 与模块数据都是本地数据，默认不提交到 Git。
+
+悬浮条 `爆发` 或鼠标侧键 4（`XBUTTON1`）可切换爆发。开启后若勾选「爆发自动关」，默认 30 秒后关闭。运行时会把状态字段 `爆发开关` 写成 `1` 或 `0`，模块条件可直接使用 `爆发开关 == 1`；关闭爆发时即使插件像素仍为开启，也会强制写成 `0`。若触发键本身就是 `XBUTTON1`，则不再用同一按键切换爆发。
 
 ## 环境要求
 
@@ -74,7 +76,7 @@ dotnet run --project .\Shigure.csproj
 可选启动参数：
 
 ```powershell
-dotnet run --project .\Shigure.csproj -- --toggle XBUTTON2 --mode switch --logic-ms 100 --render-ms 100
+dotnet run --project .\Shigure.csproj -- --toggle XBUTTON2 --mode switch --logic-ms 100 --render-ms 100 --burst-auto-off true
 ```
 
 - `wow_process.txt`：每行一个目标进程名（可带或不带 `.exe`）。程序使用 Windows Z 顺序中最靠前的候选进程可见顶层窗口，切换窗口后会自动跟随。
@@ -82,6 +84,7 @@ dotnet run --project .\Shigure.csproj -- --toggle XBUTTON2 --mode switch --logic
 - `--mode`：发送模式，支持 `switch`、`click`、`hold`。
 - `--logic-ms`：逻辑循环间隔，默认 `100` ms，最小 `50` ms。
 - `--render-ms`：UI 刷新间隔，默认 `100` ms，最小 `100` ms。
+- `--burst-auto-off`：爆发是否 30 秒后自动关闭，默认 `true`。
 
 发送模式：
 

--- a/Runtime/RenderSnapshot.cs
+++ b/Runtime/RenderSnapshot.cs
@@ -2,6 +2,8 @@ namespace Shigure;
 
 public sealed record RenderSnapshot(
     bool Enabled,
+    bool BurstActive,
+    int BurstRemainingSeconds,
     string? ClassName,
     string? SpecName,
     int? ClassId,

--- a/Runtime/ShigureRuntime.cs
+++ b/Runtime/ShigureRuntime.cs
@@ -4,6 +4,11 @@ namespace Shigure;
 
 public sealed class ShigureRuntime
 {
+    private const string BurstKeyName = "XBUTTON1";
+    private const string BurstStateKey = "爆发开关";
+    private static readonly TimeSpan BurstDuration = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan BurstDebounce = TimeSpan.FromMilliseconds(120);
+
     private readonly AppOptions _options;
     private readonly IRuntimeScreenScanner _scanner;
     private readonly IRuntimeStateBuilder _stateBuilder;
@@ -23,6 +28,8 @@ public sealed class ShigureRuntime
     private string _currentStep = "等待启动";
     private IReadOnlyDictionary<string, object?> _unitInfo = new Dictionary<string, object?>();
     private bool _enabled;
+    private bool _burstActive;
+    private DateTimeOffset _burstUntil = DateTimeOffset.MinValue;
     private bool _clickPending;
     private readonly Dictionary<string, DateTimeOffset> _lastRuleSentAt = new(StringComparer.Ordinal);
     private DateTimeOffset _logicPausedUntil = DateTimeOffset.MinValue;
@@ -59,6 +66,16 @@ public sealed class ShigureRuntime
         _pendingCommands.Enqueue(RuntimeCommand.ToggleEnabled());
     }
 
+    public void ActivateBurst()
+    {
+        _pendingCommands.Enqueue(RuntimeCommand.ActivateBurst());
+    }
+
+    public void ToggleBurst()
+    {
+        _pendingCommands.Enqueue(RuntimeCommand.ToggleBurst());
+    }
+
     private void ApplyEnabled(bool enabled)
     {
         _enabled = enabled;
@@ -73,6 +90,68 @@ public sealed class ShigureRuntime
         PublishSnapshot();
     }
 
+    private void ApplyBurst(bool active)
+    {
+        var now = _timeProvider.GetUtcNow();
+        if (active)
+        {
+            StartBurst(now);
+        }
+        else
+        {
+            ClearBurst("爆发关闭");
+        }
+
+        if (_state is not null)
+        {
+            WriteBurstState(_state);
+        }
+
+        PublishSnapshot();
+    }
+
+    private void ClearBurst(string step)
+    {
+        if (!_burstActive && _burstUntil == DateTimeOffset.MinValue)
+        {
+            return;
+        }
+
+        _burstActive = false;
+        _burstUntil = DateTimeOffset.MinValue;
+        _currentStep = step;
+    }
+
+    private void StartBurst(DateTimeOffset now)
+    {
+        _burstActive = true;
+        _burstUntil = _options.BurstAutoOff
+            ? now.Add(BurstDuration)
+            : DateTimeOffset.MaxValue;
+        _currentStep = "爆发开启";
+    }
+
+    private void WriteBurstState(GameState state)
+    {
+        state.Values[BurstStateKey] = _burstActive ? 1 : 0;
+    }
+
+    private int GetBurstRemainingSeconds(DateTimeOffset now)
+    {
+        if (!_burstActive || !_options.BurstAutoOff)
+        {
+            return 0;
+        }
+
+        var remaining = _burstUntil - now;
+        if (remaining <= TimeSpan.Zero)
+        {
+            return 0;
+        }
+
+        return (int)Math.Ceiling(remaining.TotalSeconds);
+    }
+
     private void DrainPendingCommands()
     {
         while (_pendingCommands.TryDequeue(out var command))
@@ -84,6 +163,12 @@ public sealed class ShigureRuntime
                     break;
                 case RuntimeCommandKind.ToggleEnabled:
                     ApplyEnabled(!_enabled);
+                    break;
+                case RuntimeCommandKind.ActivateBurst:
+                    ApplyBurst(true);
+                    break;
+                case RuntimeCommandKind.ToggleBurst:
+                    ApplyBurst(!_burstActive);
                     break;
             }
         }
@@ -99,10 +184,15 @@ public sealed class ShigureRuntime
             return;
         }
 
+        var burstVk = _triggerKeyState.ResolveVirtualKey(BurstKeyName);
+        var burstSharesToggleKey = burstVk is not null && burstVk.Value == toggleVk.Value;
+
         var previousPressed = false;
+        var previousBurstPressed = false;
         var lastLogicAt = DateTimeOffset.MinValue;
         var lastRenderAt = DateTimeOffset.MinValue;
         var lastToggleAt = DateTimeOffset.MinValue;
+        var lastBurstAt = DateTimeOffset.MinValue;
         _currentStep = "已启动";
         PublishSnapshot();
 
@@ -135,6 +225,27 @@ public sealed class ShigureRuntime
 
                 previousPressed = pressed;
 
+                if (!burstSharesToggleKey && burstVk is not null)
+                {
+                    var burstPressed = _triggerKeyState.IsPressed(burstVk.Value);
+                    var burstRising = burstPressed
+                        && !previousBurstPressed
+                        && now - lastBurstAt >= BurstDebounce;
+                    if (burstRising)
+                    {
+                        lastBurstAt = now;
+                        ApplyBurst(!_burstActive);
+                    }
+
+                    previousBurstPressed = burstPressed;
+                }
+
+                if (_options.BurstAutoOff && _burstActive && now >= _burstUntil)
+                {
+                    ClearBurst("爆发超时关闭");
+                    PublishSnapshot();
+                }
+
                 if (now - lastLogicAt >= _options.LogicInterval)
                 {
                     lastLogicAt = now;
@@ -156,6 +267,8 @@ public sealed class ShigureRuntime
         finally
         {
             _enabled = false;
+            _burstActive = false;
+            _burstUntil = DateTimeOffset.MinValue;
             _clickPending = false;
             _logicPausedUntil = DateTimeOffset.MinValue;
             _currentStep = "已停止";
@@ -213,6 +326,7 @@ public sealed class ShigureRuntime
         }
 
         _state = _stateBuilder.Build(scan.RowData, scan.BarData, scan.HealAbsorbData);
+        WriteBurstState(_state);
         _classId = _state.GetInt("职业");
         _specId = _state.GetInt("专精");
         (_className, _specName) = ClassNames.GetClassAndSpecName(_classId, _specId);
@@ -329,8 +443,11 @@ public sealed class ShigureRuntime
 
     private void PublishSnapshot()
     {
+        var now = _timeProvider.GetUtcNow();
         SnapshotUpdated?.Invoke(new RenderSnapshot(
             _enabled,
+            _burstActive,
+            GetBurstRemainingSeconds(now),
             _className,
             _specName,
             _classId,
@@ -419,7 +536,9 @@ public sealed class ShigureRuntime
     private enum RuntimeCommandKind
     {
         SetEnabled,
-        ToggleEnabled
+        ToggleEnabled,
+        ActivateBurst,
+        ToggleBurst
     }
 
     private readonly record struct RuntimeCommand(RuntimeCommandKind Kind, bool Enabled)
@@ -429,5 +548,11 @@ public sealed class ShigureRuntime
 
         public static RuntimeCommand ToggleEnabled()
             => new(RuntimeCommandKind.ToggleEnabled, false);
+
+        public static RuntimeCommand ActivateBurst()
+            => new(RuntimeCommandKind.ActivateBurst, true);
+
+        public static RuntimeCommand ToggleBurst()
+            => new(RuntimeCommandKind.ToggleBurst, false);
     }
 }

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -14,6 +14,9 @@ public sealed class MainForm : Form, IMessageFilter
     private const int RoundedCornerResizeDebounceMs = 80;
     private const string HeaderIconResourcePath = "Assets.arasaka-icon-transparent.png";
     private const string ModuleWebsiteUrl = "https://www.shigure.club";
+    private const double DefaultMainBarOpacity = 0.62;
+    private const double MinMainBarOpacity = 0.30;
+    private const double MaxMainBarOpacity = 1.00;
     private static readonly Color DefaultHeaderIconColor = Color.White;
     private static readonly IReadOnlyDictionary<int, Color> ClassIconColors = new Dictionary<int, Color>
     {
@@ -34,6 +37,9 @@ public sealed class MainForm : Form, IMessageFilter
 
     private Button _toggleKeyButton = null!;
     private ComboBox _modeComboBox = null!;
+    private CheckBox _burstAutoOffCheckBox = null!;
+    private TrackBar _opacityTrackBar = null!;
+    private Label _opacityValueLabel = null!;
     private ComboBox _moduleComboBox = null!;
     private Label _moduleFilterLabel = null!;
     private Label _moduleCountLabel = null!;
@@ -51,6 +57,8 @@ public sealed class MainForm : Form, IMessageFilter
 
     private readonly List<Button> _enableButtons = [];
     private Button _verticalEnableButton = null!;
+    private readonly List<Button> _burstButtons = [];
+    private Button _verticalBurstButton = null!;
     private readonly List<PictureBox> _headerIcons = [];
     private readonly List<Label> _titleLabels = [];
     private readonly List<Label> _runtimeStatusLabels = [];
@@ -81,6 +89,7 @@ public sealed class MainForm : Form, IMessageFilter
     private string? _lastLoggedClass;
     private string? _lastLoggedModule;
     private bool? _lastLoggedEnabled;
+    private bool? _lastLoggedBurst;
     private readonly object _configUpdateSync = new();
     private readonly SemaphoreSlim _moduleImportGate = new(1, 1);
     private Task _configUpdateTail = Task.CompletedTask;
@@ -582,6 +591,13 @@ public sealed class MainForm : Form, IMessageFilter
 
         var enableButton = CreateTopBarButton(vertical ? "开\r\n启" : "开关", UiTheme.Field, UiTheme.Text, vertical);
         enableButton.Click += (_, _) => ToggleEnabled();
+        var burstButton = CreateTopBarButton(vertical ? "爆\r\n发" : "爆发", UiTheme.Field, UiTheme.Text, vertical);
+        if (!vertical)
+        {
+            burstButton.Size = new Size(100, 36);
+        }
+
+        burstButton.Click += (_, _) => ToggleBurst();
         var settingsButton = CreateTopBarButton(vertical ? "设\r\n置" : "设置", UiTheme.Field, UiTheme.Text, vertical);
         settingsButton.Click += (_, _) => ShowSettingsView();
         var closeButton = CreateTopBarButton(vertical ? "X" : "✕", UiTheme.Field, UiTheme.Muted, vertical);
@@ -590,11 +606,13 @@ public sealed class MainForm : Form, IMessageFilter
         closeButton.Click += (_, _) => Close();
 
         _enableButtons.Add(enableButton);
+        _burstButtons.Add(burstButton);
         if (vertical)
         {
             _verticalEnableButton = enableButton;
+            _verticalBurstButton = burstButton;
         }
-        buttons.Controls.AddRange([enableButton, settingsButton, closeButton]);
+        buttons.Controls.AddRange([enableButton, burstButton, settingsButton, closeButton]);
         return buttons;
     }
 
@@ -747,7 +765,7 @@ public sealed class MainForm : Form, IMessageFilter
         {
             Dock = DockStyle.Fill,
             ColumnCount = 2,
-            RowCount = 4,
+            RowCount = 6,
             Padding = new Padding(18),
             Margin = new Padding(0, 0, 7, 14)
         };
@@ -757,9 +775,11 @@ public sealed class MainForm : Form, IMessageFilter
         inputCard.RowStyles.Add(new RowStyle(SizeType.Absolute, 38));
         inputCard.RowStyles.Add(new RowStyle(SizeType.Absolute, settingsActionButtonHeight + 8));
         inputCard.RowStyles.Add(new RowStyle(SizeType.Absolute, settingsActionButtonHeight + 8));
+        inputCard.RowStyles.Add(new RowStyle(SizeType.Absolute, settingsActionButtonHeight + 8));
+        inputCard.RowStyles.Add(new RowStyle(SizeType.Absolute, settingsActionButtonHeight + 8));
         inputCard.Controls.Add(CreateTitle("输入与运行"), 0, 0);
         inputCard.SetColumnSpan(inputCard.GetControlFromPosition(0, 0)!, 2);
-        inputCard.Controls.Add(CreateDescription("设置触发方式；修改后运行循环会自动重启"), 0, 1);
+        inputCard.Controls.Add(CreateDescription("设置触发方式、爆发与悬浮条透明度"), 0, 1);
         inputCard.SetColumnSpan(inputCard.GetControlFromPosition(0, 1)!, 2);
 
         _toggleKeyButton = UiTheme.CreateButton("XBUTTON2", UiTheme.ButtonKind.Secondary);
@@ -783,6 +803,56 @@ public sealed class MainForm : Form, IMessageFilter
         _settingsToolTip.SetToolTip(_modeComboBox, "开关：按一次切换；单击：每次触发发送一次；按住：持续按下时运行");
         inputCard.Controls.Add(CreateSettingLabel("发送模式"), 0, 3);
         inputCard.Controls.Add(_modeComboBox, 1, 3);
+
+        _burstAutoOffCheckBox = new CheckBox
+        {
+            Text = "开启后 30 秒自动关闭",
+            AutoSize = true,
+            Anchor = AnchorStyles.Left,
+            ForeColor = UiTheme.Text,
+            Margin = new Padding(0),
+            Checked = true
+        };
+        _settingsToolTip.SetToolTip(_burstAutoOffCheckBox, "关闭后爆发需手动关闭；鼠标4可切换爆发开/关");
+        inputCard.Controls.Add(CreateSettingLabel("爆发自动关"), 0, 4);
+        inputCard.Controls.Add(_burstAutoOffCheckBox, 1, 4);
+
+        var opacityHost = new FlowLayoutPanel
+        {
+            AutoSize = true,
+            Anchor = AnchorStyles.Left,
+            FlowDirection = FlowDirection.LeftToRight,
+            WrapContents = false,
+            BackColor = Color.Transparent,
+            Margin = new Padding(0),
+            Padding = new Padding(0)
+        };
+        _opacityTrackBar = new TrackBar
+        {
+            Minimum = 30,
+            Maximum = 100,
+            TickFrequency = 10,
+            SmallChange = 5,
+            LargeChange = 10,
+            Width = 150,
+            Height = settingsActionButtonHeight,
+            Margin = new Padding(0, 0, 8, 0),
+            AutoSize = false,
+            TickStyle = TickStyle.None
+        };
+        _opacityValueLabel = new Label
+        {
+            AutoSize = true,
+            Anchor = AnchorStyles.Left,
+            ForeColor = UiTheme.Muted,
+            Margin = new Padding(0, 8, 0, 0),
+            Text = "62%"
+        };
+        _settingsToolTip.SetToolTip(_opacityTrackBar, "降低悬浮条不透明度，减少挡视野");
+        opacityHost.Controls.Add(_opacityTrackBar);
+        opacityHost.Controls.Add(_opacityValueLabel);
+        inputCard.Controls.Add(CreateSettingLabel("悬浮透明"), 0, 5);
+        inputCard.Controls.Add(opacityHost, 1, 5);
 
         var configCard = new UiCardPanel
         {
@@ -1340,13 +1410,62 @@ public sealed class MainForm : Form, IMessageFilter
             SendMode.Hold => 2,
             _ => 0
         };
+        _burstAutoOffCheckBox.Checked = _uiCache.BurstAutoOff ?? _initialOptions.BurstAutoOff;
+        ApplyOpacityToControls(ResolveCachedOpacity(), save: false);
         RefreshModuleSelector(_lastSnapshot, forceRefresh: false);
     }
 
     private void WireSettingEvents()
     {
         _modeComboBox.SelectedIndexChanged += HandleSettingCommitted;
+        _burstAutoOffCheckBox.CheckedChanged += HandleBurstAutoOffChanged;
+        _opacityTrackBar.ValueChanged += HandleOpacityChanged;
         _moduleComboBox.SelectedIndexChanged += HandleModuleSelectionChanged;
+    }
+
+    private async void HandleBurstAutoOffChanged(object? sender, EventArgs e)
+    {
+        SaveUiCache();
+        await RestartRuntimeAfterSettingChangeAsync();
+    }
+
+    private void HandleOpacityChanged(object? sender, EventArgs e)
+    {
+        var opacity = ClampOpacity(_opacityTrackBar.Value / 100.0);
+        ApplyOpacityToControls(opacity, save: true);
+    }
+
+    private void ApplyOpacityToControls(double opacity, bool save)
+    {
+        opacity = ClampOpacity(opacity);
+        var percent = (int)Math.Round(opacity * 100);
+        if (_opacityTrackBar.Value != percent)
+        {
+            _opacityTrackBar.Value = percent;
+        }
+
+        _opacityValueLabel.Text = $"{percent}%";
+        Opacity = opacity;
+        if (save)
+        {
+            _uiCache.MainBarOpacity = opacity;
+            SaveUiCache();
+        }
+    }
+
+    private double ResolveCachedOpacity()
+    {
+        return ClampOpacity(_uiCache.MainBarOpacity ?? DefaultMainBarOpacity);
+    }
+
+    private static double ClampOpacity(double opacity)
+    {
+        if (double.IsNaN(opacity) || double.IsInfinity(opacity))
+        {
+            return DefaultMainBarOpacity;
+        }
+
+        return Math.Clamp(opacity, MinMainBarOpacity, MaxMainBarOpacity);
     }
 
     private async void HandleSettingCommitted(object? sender, EventArgs e)
@@ -1457,6 +1576,7 @@ public sealed class MainForm : Form, IMessageFilter
         _lastLoggedClass = null;
         _lastLoggedModule = null;
         _lastLoggedEnabled = null;
+        _lastLoggedBurst = null;
     }
 
     private async Task RestartRuntimeFromEditorAsync()
@@ -1481,13 +1601,29 @@ public sealed class MainForm : Form, IMessageFilter
         _runtimeSession.ToggleEnabled();
     }
 
+    private void ToggleBurst()
+    {
+        if (!_runtimeSession.IsRunning)
+        {
+            return;
+        }
+
+        _runtimeSession.ToggleBurst();
+    }
+
     private AppOptions BuildOptions()
     {
         var toggleKey = string.IsNullOrWhiteSpace(_toggleKeyName)
             ? "XBUTTON2"
             : _toggleKeyName.Trim();
 
-        return _initialOptions with { ToggleKey = toggleKey, Mode = ReadMode(), ModuleId = _selectedModuleId };
+        return _initialOptions with
+        {
+            ToggleKey = toggleKey,
+            Mode = ReadMode(),
+            ModuleId = _selectedModuleId,
+            BurstAutoOff = _burstAutoOffCheckBox.Checked
+        };
     }
 
     private SendMode ReadMode()
@@ -1551,6 +1687,24 @@ public sealed class MainForm : Form, IMessageFilter
             enableButton.Text = enableButton == _verticalEnableButton
                 ? snapshot.Enabled ? "关\r\n闭" : "开\r\n启"
                 : snapshot.Enabled ? "关闭" : "开启";
+        }
+
+        foreach (var burstButton in _burstButtons)
+        {
+            if (burstButton == _verticalBurstButton)
+            {
+                burstButton.Text = snapshot.BurstActive ? "爆\r\n发" : "爆\r\n发";
+            }
+            else
+            {
+                burstButton.Text = snapshot.BurstActive
+                    ? (snapshot.BurstRemainingSeconds > 0
+                        ? $"爆发 {snapshot.BurstRemainingSeconds}s"
+                        : "爆发中")
+                    : "爆发";
+            }
+
+            burstButton.ForeColor = snapshot.BurstActive ? UiTheme.Accent : UiTheme.Text;
         }
 
         RefreshModuleSelector(snapshot, forceRefresh: false);
@@ -1721,6 +1875,16 @@ public sealed class MainForm : Form, IMessageFilter
             AppendLog(snapshot.Enabled ? "逻辑已开启" : "逻辑已关闭");
         }
 
+        if (_lastLoggedBurst != snapshot.BurstActive)
+        {
+            _lastLoggedBurst = snapshot.BurstActive;
+            AppendLog(snapshot.BurstActive
+                ? (snapshot.BurstRemainingSeconds > 0
+                    ? $"爆发已开启（{snapshot.BurstRemainingSeconds}s）"
+                    : "爆发已开启")
+                : "爆发已关闭");
+        }
+
         if (snapshot.ModuleName != _lastLoggedModule)
         {
             _lastLoggedModule = snapshot.ModuleName;
@@ -1783,6 +1947,16 @@ public sealed class MainForm : Form, IMessageFilter
         foreach (var enableButton in _enableButtons)
         {
             enableButton.Enabled = running;
+        }
+
+        foreach (var burstButton in _burstButtons)
+        {
+            burstButton.Enabled = running;
+            if (!running)
+            {
+                burstButton.Text = burstButton == _verticalBurstButton ? "爆\r\n发" : "爆发";
+                burstButton.ForeColor = UiTheme.Text;
+            }
         }
     }
 
@@ -1975,6 +2149,8 @@ public sealed class MainForm : Form, IMessageFilter
 
         _uiCache.MainWindowLayout = _mainWindowLayout.ToString();
         _uiCache.ToggleKey = _toggleKeyName;
+        _uiCache.BurstAutoOff = _burstAutoOffCheckBox.Checked;
+        _uiCache.MainBarOpacity = ClampOpacity(_opacityTrackBar.Value / 100.0);
         _uiCache.SelectedModuleId = _selectedModuleId;
         UiCacheStore.Save(_uiCache);
     }


### PR DESCRIPTION
## Summary
- 悬浮条增加 `爆发` 按钮，鼠标侧键 4（`XBUTTON1`）可切换爆发。开启后默认 30 秒自动关闭，也可在 `通用` 页关掉自动关。
- 运行时把状态字段 `爆发开关` 写成 `1` / `0`；关闭爆发时即使插件像素仍为开启，也会强制写成 `0`。模块条件可直接写 `爆发开关 == 1`。
- 通用页增加悬浮条透明度滑条（30%～100%，默认 62%），减少挡视野；透明度与爆发自动关会写入本地窗口缓存。

不含改名、技能就绪判断或职业模块 JSON。

## Test plan
- [ ] 点悬浮条 `爆发`：日志显示爆发已开启，状态页 `爆发开关` 为 1；再点一次关闭为 0
- [ ] 鼠标侧键 4 可切换爆发；若触发键设为 `XBUTTON1`，则不再用同一键切爆发
- [ ] 勾选「爆发自动关」后约 30 秒自动关闭；取消勾选后需手动关
- [ ] 模块条件 `爆发开关 == 1` 仅在爆发开启时命中
- [ ] 关闭爆发后，即使插件像素仍显示开启，`爆发开关` 仍为 0
- [ ] 调整悬浮透明后主条变淡，重启程序后透明度保持

Made with [Cursor](https://cursor.com)