### PR TITLE
功能：支持玩家所有权过滤及目标/焦点 Aura 层数

### DIFF
--- a/Fuyutsui/core/block.lua
+++ b/Fuyutsui/core/block.lua
@@ -567,7 +567,7 @@ local function IsAuraFilterAllowedForUnit(unit, filter)
     if filter == "HELPFUL" or filter == "HELPFUL|PLAYER" then
         return UnitCanAssist("player", unit) and true or false
     end
-    if filter == "HARMFUL" then
+    if filter == "HARMFUL" or filter == "HARMFUL|PLAYER" then
         return UnitCanAttack("player", unit) and not UnitCanAssist("player", unit)
     end
     return true

--- a/Fuyutsui/core/block.lua
+++ b/Fuyutsui/core/block.lua
@@ -727,7 +727,11 @@ local function RebindContainerSpellFilters(container, unit)
             return (a.index or 0) < (b.index or 0)
         end)
         for _, slot in ipairs(container.fuyutsuiBarSlots) do
-            container:SetAuraSlotCandidateFilters(slot.key, AuraSlotFilters(slot.includeSpellIDs))
+            if IsAuraFilterAllowedForUnit(bindUnit or "player", slot.filter or "HELPFUL") then
+                container:SetAuraSlotCandidateFilters(slot.key, AuraSlotFilters(slot.includeSpellIDs))
+            else
+                container:SetAuraSlotCandidateFilters(slot.key, AURA_MATCH_NONE_FILTERS)
+            end
         end
     end
     if container.fuyutsuiSpellIdSlots then
@@ -848,9 +852,9 @@ local function MakeBarSlotInitializer(slotInfo)
     end
 end
 
-local function CollectPlayerAuraAppSlots()
+local function CollectAuraAppSlots()
     local appSlots = {}
-    for _, info in ipairs(CollectAuraSpellSlots("player")) do
+    for _, info in ipairs(CollectAuraSpellSlots()) do
         if info.maxApps then
             tinsert(appSlots, info)
         end
@@ -865,7 +869,7 @@ local function ReclaimAuraBarLayoutSpace()
     UpdateHorizontalBarEndMarker()
 end
 
-local function ReanchorPlayerAuraBarSlots(container)
+local function ReanchorAuraBarSlots(container)
     local slots = container and container.fuyutsuiBarSlots
     if not slots then
         return
@@ -900,7 +904,12 @@ function Fuyutsui:ReleaseUnitAuraContainers()
         ReleaseFrame(Fuyutsui[key])
         Fuyutsui[key] = nil
     end
-    ReleaseFrame(Fuyutsui.PlayerAuraBarContainer)
+    if Fuyutsui.UnitAuraBarContainers then
+        for _, container in pairs(Fuyutsui.UnitAuraBarContainers) do
+            ReleaseFrame(container)
+        end
+    end
+    Fuyutsui.UnitAuraBarContainers = nil
     Fuyutsui.PlayerAuraBarContainer = nil
     ReclaimAuraBarLayoutSpace()
 end
@@ -1004,6 +1013,8 @@ function Fuyutsui:UpdateUnitAuraContainer(unit)
         return
     end
     RebindContainerSpellFilters(Fuyutsui[key], unit)
+    local barContainers = Fuyutsui.UnitAuraBarContainers
+    RebindContainerSpellFilters(barContainers and barContainers[unit], unit)
 end
 
 -- 兼容旧名
@@ -1011,32 +1022,43 @@ function Fuyutsui:RefreshPlayerAuraContainers()
     self:RefreshUnitAuraContainers()
 end
 
---- 在计数条之后排布层数条，最后放置 BAR_END_COLOR（仅玩家光环 maxApps）
---- 按 auras 索引升序固定条序；若容器已存在但槽位集合变化则整表重建
+--- 在计数条之后排布层数条，最后放置 BAR_END_COLOR。
+--- 每个 unit 使用独立 AuraContainer，支持 player/target/focus 的 maxApps。
 function Fuyutsui:LayoutAuraApplicationBars()
-    local appSlots = CollectPlayerAuraAppSlots()
-    local barSlots = Fuyutsui.PlayerAuraBarContainer
-    if barSlots and barSlots.fuyutsuiBarSlots then
-        local existing = barSlots.fuyutsuiBarSlots
-        local same = auraBarLaidOut and #existing == #appSlots
+    local appSlots = CollectAuraAppSlots()
+    local containers = Fuyutsui.UnitAuraBarContainers
+    if containers then
+        local existingByIndex = {}
+        local existingCount = 0
+        for unit, container in pairs(containers) do
+            for _, slot in ipairs(container.fuyutsuiBarSlots or {}) do
+                slot.unit = slot.unit or unit
+                existingByIndex[slot.index] = slot
+                existingCount = existingCount + 1
+            end
+        end
+        local same = auraBarLaidOut and existingCount == #appSlots
         if same then
-            for i, info in ipairs(appSlots) do
-                local slot = existing[i]
-                if not slot or slot.index ~= info.index or slot.maxApps ~= info.maxApps then
+            for _, info in ipairs(appSlots) do
+                local slot = existingByIndex[info.index]
+                if not slot or slot.maxApps ~= info.maxApps or slot.unit ~= info.unit then
                     same = false
                     break
                 end
             end
         end
         if not same then
-            ReleaseFrame(barSlots)
+            for _, container in pairs(containers) do
+                ReleaseFrame(container)
+            end
+            Fuyutsui.UnitAuraBarContainers = nil
             Fuyutsui.PlayerAuraBarContainer = nil
             ReclaimAuraBarLayoutSpace()
-            barSlots = nil
+            containers = nil
         end
     end
 
-    if auraBarLaidOut and Fuyutsui.PlayerAuraBarContainer then
+    if auraBarLaidOut and Fuyutsui.UnitAuraBarContainers then
         return
     end
 
@@ -1046,45 +1068,52 @@ function Fuyutsui:LayoutAuraApplicationBars()
 
     if #appSlots > 0 then
         EnsureAuraContainerLoaded()
+        containers = {}
+        Fuyutsui.UnitAuraBarContainers = containers
 
-        if not barSlots then
-            barSlots = CreateFrame("AuraContainer", "FuyutsuiPlayerAuraBarSlots", countBars,
-                                   "CustomAuraContainerTemplate")
-            barSlots:SetPoint("TOPLEFT", countBars, "TOPLEFT", 0, 0)
-            barSlots:SetUnit("player")
-            barSlots:SetEnabled(true)
-            barSlots:SetFrameStrata(AURA_BAR_STRATA)
-            barSlots:SetFrameLevel(AURA_BAR_LEVEL)
-            Fuyutsui.PlayerAuraBarContainer = barSlots
-            barSlots.fuyutsuiBarSlots = {}
-
-            for _, info in ipairs(appSlots) do
-                local startIndex = ReserveHorizontalBarUnits(
-                    info.maxApps,
-                    "警告: Fuyutsui_CountBars 光环层数条空间不足!"
-                )
-                if not startIndex then
-                    break
-                end
-                CreateHorizontalBarBackgrounds(startIndex, info.maxApps)
-                local slotKey = "bar_index_" .. info.index
-                local slotInfo = {
-                    key = slotKey,
-                    index = info.index,
-                    maxApps = info.maxApps,
-                    startIndex = startIndex,
-                    includeSpellIDs = info.includeSpellIDs,
-                }
-                barSlots:AddAuraSlot(slotKey, info.filter or "HELPFUL", {
-                    candidateFilters = AuraSlotFilters(info.includeSpellIDs),
-                    sortMethod = AuraContainerSortMethod.Expiration,
-                    sortDirection = AuraContainerSortDirection.Normal,
-                    initializeFrame = MakeBarSlotInitializer(slotInfo),
-                })
-                tinsert(barSlots.fuyutsuiBarSlots, slotInfo)
+        for _, info in ipairs(appSlots) do
+            local unit = info.unit or "player"
+            local barSlots = containers[unit]
+            if not barSlots then
+                barSlots = CreateFrame("AuraContainer", nil, countBars, "CustomAuraContainerTemplate")
+                barSlots:SetPoint("TOPLEFT", countBars, "TOPLEFT", 0, 0)
+                barSlots:SetUnit(unit)
+                barSlots:SetEnabled(true)
+                barSlots:SetFrameStrata(AURA_BAR_STRATA)
+                barSlots:SetFrameLevel(AURA_BAR_LEVEL)
+                barSlots.fuyutsuiBarSlots = {}
+                barSlots.fuyutsuiUnit = unit
+                containers[unit] = barSlots
             end
-            barSlots.fuyutsuiUnit = "player"
+
+            local startIndex = ReserveHorizontalBarUnits(
+                info.maxApps,
+                "警告: Fuyutsui_CountBars 光环层数条空间不足!"
+            )
+            if not startIndex then
+                break
+            end
+            CreateHorizontalBarBackgrounds(startIndex, info.maxApps)
+            local slotKey = "bar_index_" .. info.index
+            local slotInfo = {
+                key = slotKey,
+                index = info.index,
+                maxApps = info.maxApps,
+                startIndex = startIndex,
+                includeSpellIDs = info.includeSpellIDs,
+                filter = info.filter,
+                unit = unit,
+            }
+            barSlots:AddAuraSlot(slotKey, info.filter or "HELPFUL", {
+                candidateFilters = AuraSlotFilters(info.includeSpellIDs),
+                sortMethod = AuraContainerSortMethod.Expiration,
+                sortDirection = AuraContainerSortDirection.Normal,
+                initializeFrame = MakeBarSlotInitializer(slotInfo),
+            })
+            tinsert(barSlots.fuyutsuiBarSlots, slotInfo)
         end
+
+        Fuyutsui.PlayerAuraBarContainer = containers.player
     end
 
     UpdateHorizontalBarEndMarker()
@@ -1355,17 +1384,23 @@ function Fuyutsui:RebindAuraSpellFilters()
 
     -- 层数条：按 auras 索引同步槽位；集合变化时整表重建，并重锚保证条序
     self:LayoutAuraApplicationBars()
-    local barContainer = Fuyutsui.PlayerAuraBarContainer
-    if barContainer and barContainer.fuyutsuiBarSlots then
-        local appSlots = CollectPlayerAuraAppSlots()
-        for i, slot in ipairs(barContainer.fuyutsuiBarSlots) do
-            local info = appSlots[i]
-            if info then
-                slot.includeSpellIDs = info.includeSpellIDs
+    local appSlots = CollectAuraAppSlots()
+    local infoByIndex = {}
+    for _, info in ipairs(appSlots) do
+        infoByIndex[info.index] = info
+    end
+    for unit, barContainer in pairs(Fuyutsui.UnitAuraBarContainers or {}) do
+        if barContainer.fuyutsuiBarSlots then
+            for _, slot in ipairs(barContainer.fuyutsuiBarSlots) do
+                local info = infoByIndex[slot.index]
+                if info then
+                    slot.includeSpellIDs = info.includeSpellIDs
+                    slot.filter = info.filter
+                end
             end
+            RebindContainerSpellFilters(barContainer, unit)
+            ReanchorAuraBarSlots(barContainer)
         end
-        RebindContainerSpellFilters(barContainer, "player")
-        ReanchorPlayerAuraBarSlots(barContainer)
     end
 
     RefreshAllCreatedBars()

--- a/Fuyutsui/main.lua
+++ b/Fuyutsui/main.lua
@@ -100,7 +100,7 @@ function Fuyutsui:LoadPlayerBlocks(specIndex)
                         spellIds = aura.spellIds,
                         maxApps = aura.maxApps,
                         unit = unit,
-                        filter = filter,
+                        filter = aura.filter or filter,
                     }
                     index = index + 1
                 else

--- a/Infrastructure/ClassBlocksStore.cs
+++ b/Infrastructure/ClassBlocksStore.cs
@@ -73,6 +73,7 @@ internal static class ClassBlocksStore
         public long? SpellId { get; set; }
         public List<long> SpellIds { get; } = new();
         public int? MaxApps { get; set; }
+        public string? Filter { get; set; }
     }
 
     public sealed class SpellEntry
@@ -480,7 +481,8 @@ internal static class ClassBlocksStore
             var entry = new AuraEntry
             {
                 Name = aura.GetString("name")?.Trim() ?? string.Empty,
-                MaxApps = aura.GetNumber("maxApps") is { } maxApps ? (int)maxApps : null
+                MaxApps = aura.GetNumber("maxApps") is { } maxApps ? (int)maxApps : null,
+                Filter = aura.GetString("filter")?.Trim()
             };
             if (aura.GetNumber("spellId") is { } sid)
             {
@@ -719,6 +721,10 @@ internal static class ClassBlocksStore
         if (aura.MaxApps is { } maxApps)
         {
             sb.Append(" maxApps = ").Append(maxApps).Append(',');
+        }
+        if (!string.IsNullOrWhiteSpace(aura.Filter))
+        {
+            sb.Append(" filter = \"").Append(Escape(aura.Filter)).Append("\",");
         }
 
         sb.AppendLine(" },");

--- a/Infrastructure/FuyutsuiConfigConverter.cs
+++ b/Infrastructure/FuyutsuiConfigConverter.cs
@@ -240,9 +240,9 @@ internal static class FuyutsuiConfigConverter
         }
 
         var aurasObject = new JsonObject();
-        var playerAuraBarNames = new List<string>();
+        var auraBarNames = new List<string>();
 
-        // auras：主色块按 player → target → focus；层数条仅 player.maxApps，且排在 spell 条之后
+        // auras：主色块按 player → target → focus；所有 unit 的 maxApps 层数条排在 spell 条之后
         if (spec.GetTable("auras") is { } auras)
         {
             var nested = auras.GetTable("player") is not null
@@ -251,22 +251,22 @@ internal static class FuyutsuiConfigConverter
 
             if (nested)
             {
-                AppendAuraList(auras.GetTable("player"), "player", aurasObject, ref index, playerAuraBarNames, warnings, label);
+                AppendAuraList(auras.GetTable("player"), "player", aurasObject, ref index, auraBarNames, warnings, label);
                 if (auras.GetTable("target") is { } target)
                 {
-                    AppendAuraList(target.GetTable("harmful"), "target", aurasObject, ref index, playerAuraBarNames, warnings, label);
-                    AppendAuraList(target.GetTable("helpful"), "target", aurasObject, ref index, playerAuraBarNames, warnings, label);
+                    AppendAuraList(target.GetTable("harmful"), "target", aurasObject, ref index, auraBarNames, warnings, label);
+                    AppendAuraList(target.GetTable("helpful"), "target", aurasObject, ref index, auraBarNames, warnings, label);
                 }
 
                 if (auras.GetTable("focus") is { } focus)
                 {
-                    AppendAuraList(focus.GetTable("harmful"), "focus", aurasObject, ref index, playerAuraBarNames, warnings, label);
-                    AppendAuraList(focus.GetTable("helpful"), "focus", aurasObject, ref index, playerAuraBarNames, warnings, label);
+                    AppendAuraList(focus.GetTable("harmful"), "focus", aurasObject, ref index, auraBarNames, warnings, label);
+                    AppendAuraList(focus.GetTable("helpful"), "focus", aurasObject, ref index, auraBarNames, warnings, label);
                 }
             }
             else
             {
-                AppendAuraList(auras, "player", aurasObject, ref index, playerAuraBarNames, warnings, label);
+                AppendAuraList(auras, "player", aurasObject, ref index, auraBarNames, warnings, label);
             }
         }
 
@@ -330,7 +330,7 @@ internal static class FuyutsuiConfigConverter
             }
         }
 
-        foreach (var barName in playerAuraBarNames)
+        foreach (var barName in auraBarNames)
         {
             aurasObject[barName] = BarField(barIndex++);
         }
@@ -396,7 +396,7 @@ internal static class FuyutsuiConfigConverter
         string unit,
         JsonObject aurasObject,
         ref int index,
-        List<string> playerAuraBarNames,
+        List<string> auraBarNames,
         List<string> warnings,
         string label)
     {
@@ -434,9 +434,9 @@ internal static class FuyutsuiConfigConverter
             aurasObject[fieldName] = Field(index, "int");
             index++;
 
-            if (aura.GetNumber("maxApps") is not null && unit == "player")
+            if (aura.GetNumber("maxApps") is not null)
             {
-                playerAuraBarNames.Add(EnsureSuffix(name, "层数"));
+                auraBarNames.Add(EnsureSuffix(fieldName, "层数"));
             }
         }
     }

--- a/Infrastructure/ModuleDependencyService.cs
+++ b/Infrastructure/ModuleDependencyService.cs
@@ -247,7 +247,8 @@ internal sealed class ModuleDependencyService
         Name = entry.Name,
         SpellId = entry.SpellId,
         SpellIds = new List<long>(entry.SpellIds),
-        MaxApps = entry.MaxApps
+        MaxApps = entry.MaxApps,
+        Filter = entry.Filter
     };
 
     private static ModuleMacroEntrySnapshot CaptureMacro(ClassMacrosStore.ArrayEntry entry) => new()
@@ -334,7 +335,8 @@ internal sealed class ModuleDependencyService
             {
                 Name = entry.Name,
                 SpellId = entry.SpellId,
-                MaxApps = entry.MaxApps
+                MaxApps = entry.MaxApps,
+                Filter = entry.Filter
             };
             added.SpellIds.AddRange(entry.SpellIds);
             local.Add(added);
@@ -675,6 +677,7 @@ internal sealed class ModuleDependencyService
     private static bool AuraEquals(ClassBlocksStore.AuraEntry left, ModuleAuraSnapshot right)
         => left.SpellId == right.SpellId
            && left.MaxApps == right.MaxApps
+           && string.Equals(left.Filter, right.Filter, StringComparison.Ordinal)
            && left.SpellIds.SequenceEqual(right.SpellIds);
 
     private static bool SpellEquals(ClassBlocksStore.SpellEntry left, ModuleSpellSnapshot right)

--- a/Modules/ModuleDependencies.cs
+++ b/Modules/ModuleDependencies.cs
@@ -73,13 +73,15 @@ public sealed class ModuleAuraSnapshot
     public long? SpellId { get; set; }
     public List<long> SpellIds { get; set; } = new();
     public int? MaxApps { get; set; }
+    public string? Filter { get; set; }
 
     public ModuleAuraSnapshot Clone() => new()
     {
         Name = Name,
         SpellId = SpellId,
         SpellIds = new List<long>(SpellIds ?? []),
-        MaxApps = MaxApps
+        MaxApps = MaxApps,
+        Filter = Filter
     };
 }
 


### PR DESCRIPTION
## 改动说明

本 PR 包含两个彼此独立、与具体职业循环无关的 Aura 通用扩展：

1. **目标/焦点 Aura 层数**
   - 将 `maxApps` 层数条从仅支持 `player` 扩展到 `player/target/focus`。
   - 配置转换器生成 `目标XXX层数`、`焦点XXX层数` 字段。
   - 秘密层数仍由 Blizzard `AuraContainer` 与 `SetApplicationBar` 绘制，Lua 不读取或计算 Secret Value。
   - 可用于敏锐/刺杀死亡猎手英雄天赋的目标“死亡猎手标记”层数；上游已有的德鲁伊目标“痛击 maxApps=5”声明也能真正生成层数字段。

2. **模块 Aura 支持 Filter**
   - `Dependencies` 的 Aura 快照新增可选 `Filter`，贯通读取、合并、保存和 Lua 创建容器。
   - 支持模块声明 `HARMFUL|PLAYER`，只匹配玩家自己施放的敌方 Debuff。
   - 解决队伍中有同职业玩家时，同 spellID 的锁喉、割裂、死亡猎手标记等 Debuff 可能串数据，导致错误判断是否需要补 Debuff 的问题。
   - 未声明 `Filter` 的旧模块继续使用原默认过滤规则，行为不变。

## 提交

- `8870bae`：支持目标和焦点 Aura 层数
- `1402ada`：模块依赖保留 Aura Filter

## 验证

- Debug/Release 构建：0 warning、0 error
- 33 个插件 Lua 文件解析通过
- 德鲁伊现有目标“痛击 maxApps=5”可生成“目标痛击层数”
- `HARMFUL|PLAYER` 经 ClassBlocks 读取、模块依赖保存和回写后保持不变