### PR TITLE
修复检查更新 404：回退到 GitHub 发布页直链

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1242,7 +1242,7 @@ public sealed class MainForm : Form, IMessageFilter
         ConfigureSettingsCardRows(spellIconPackageCard, 32, 30, null, settingsActionButtonHeight);
         spellIconPackageCard.Controls.Add(CreateTitle("下载数据包"), 0, 0);
         spellIconPackageCard.Controls.Add(
-            CreateDescription("从 GitHub 下载或更新技能/物品图标数据包；不会随发布包自动附带"),
+            CreateDescription("从 GitHub Release 下载或更新技能/物品图标数据包；API 不可用时回退到发布页直链"),
             0,
             1);
 

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1339,15 +1339,35 @@ public sealed class MainForm : Form, IMessageFilter
         {
             if (!_shutdownStarted)
             {
-                _spellIconPackageStatusLabel.Text = $"下载失败：{ex.Message}";
-                _settingsToolTip.SetToolTip(_spellIconPackageStatusLabel, ex.ToString());
+                var releaseUrl = SpellIconPackageDownloadService.ReleasesPageUrl;
+                var status = $"下载失败，请到 {releaseUrl} 手动下载 SpellIcons.shgpack。";
+                _spellIconPackageStatusLabel.Text = status;
+                _settingsToolTip.SetToolTip(
+                    _spellIconPackageStatusLabel,
+                    status + Environment.NewLine + Environment.NewLine + ex);
                 AppendLog($"技能/物品图标数据包下载失败: {ex.Message}");
-                MessageBox.Show(
+                var openPage = MessageBox.Show(
                     this,
-                    ex.Message,
+                    "自动下载失败。请到以下页面手动下载 SpellIcons.shgpack，放到程序目录的 data 文件夹："
+                    + Environment.NewLine
+                    + Environment.NewLine
+                    + releaseUrl
+                    + Environment.NewLine
+                    + Environment.NewLine
+                    + $"保存位置：{SpellIconCatalog.PackagePath}"
+                    + Environment.NewLine
+                    + Environment.NewLine
+                    + $"原因：{ex.Message}"
+                    + Environment.NewLine
+                    + Environment.NewLine
+                    + "是否现在打开下载页面？",
                     "下载数据包失败",
-                    MessageBoxButtons.OK,
+                    MessageBoxButtons.YesNo,
                     MessageBoxIcon.Warning);
+                if (openPage == DialogResult.Yes)
+                {
+                    OpenSpellIconReleasePage();
+                }
             }
         }
         finally
@@ -1405,6 +1425,30 @@ public sealed class MainForm : Form, IMessageFilter
             MessageBox.Show(
                 this,
                 $"无法打开模块网站：{ex.Message}",
+                "Shigure",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Warning);
+        }
+    }
+
+    private void OpenSpellIconReleasePage()
+    {
+        var releaseUrl = SpellIconPackageDownloadService.ReleasesPageUrl;
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(releaseUrl)
+            {
+                UseShellExecute = true
+            });
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(
+                this,
+                $"无法打开下载页面：{ex.Message}"
+                + Environment.NewLine
+                + Environment.NewLine
+                + releaseUrl,
                 "Shigure",
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Warning);

--- a/UI/SpellIconPackageDownloadService.cs
+++ b/UI/SpellIconPackageDownloadService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text.Json;
@@ -16,7 +17,14 @@ internal sealed class SpellIconPackageDownloadService : IDisposable
 {
     internal const string LatestReleaseApiUrl =
         "https://api.github.com/repos/waynebian01/Shigure/releases/latest";
+    internal const string LatestBrowserDownloadUrl =
+        "https://github.com/waynebian01/Shigure/releases/latest/download/SpellIcons.shgpack";
+    internal const string ReleasesPageUrl =
+        "https://github.com/waynebian01/Shigure/releases";
+    private const string ReleasesApiUrl =
+        "https://api.github.com/repos/waynebian01/Shigure/releases?per_page=20";
     private const string AssetName = "SpellIcons.shgpack";
+    private static readonly TimeSpan ApiRequestTimeout = TimeSpan.FromSeconds(15);
 
     private readonly HttpClient _httpClient;
 
@@ -27,33 +35,41 @@ internal sealed class SpellIconPackageDownloadService : IDisposable
             Timeout = Timeout.InfiniteTimeSpan
         };
         _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Shigure", "1.0"));
-        _httpClient.DefaultRequestHeaders.Accept.Add(
-            new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
-        _httpClient.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
     }
 
     public async Task<SpellIconDownloadResult> UpdateAsync(
         IProgress<SpellIconDownloadProgress>? progress,
         CancellationToken cancellationToken)
     {
-        progress?.Report(new SpellIconDownloadProgress("正在读取 GitHub 最新正式版本……"));
         // UpdateAsync is invoked by MainForm. Preserve that UI context so the final hot swap
         // cannot dispose images while a DataGridView is painting them on the UI thread.
-        var asset = await GetLatestAssetAsync(cancellationToken);
+        var asset = await ResolveLatestAssetAsync(progress, cancellationToken);
 
         var localPath = SpellIconCatalog.PackagePath;
-        if (File.Exists(localPath))
+        if (File.Exists(localPath) && SpellIconCatalog.IsPackageAvailable)
         {
-            progress?.Report(new SpellIconDownloadProgress("正在比较本地与远端 SHA-256……"));
-            var localHash = await ComputeSha256Async(localPath, cancellationToken);
-            if (string.Equals(localHash, asset.Sha256, StringComparison.OrdinalIgnoreCase)
-                && SpellIconCatalog.IsPackageAvailable)
+            if (asset.Sha256 is not null)
             {
+                progress?.Report(new SpellIconDownloadProgress("正在比较本地与远端 SHA-256……"));
+                var localHash = await ComputeSha256Async(localPath, cancellationToken);
+                if (string.Equals(localHash, asset.Sha256, StringComparison.OrdinalIgnoreCase))
+                {
+                    return new SpellIconDownloadResult(
+                        Changed: false,
+                        UpToDate: true,
+                        asset.Size ?? new FileInfo(localPath).Length,
+                        localHash);
+                }
+            }
+            else if (asset.Size is { } remoteSize && new FileInfo(localPath).Length == remoteSize)
+            {
+                progress?.Report(new SpellIconDownloadProgress("正在比较本地与远端文件大小……"));
+                var localHash = await ComputeSha256Async(localPath, cancellationToken);
                 return new SpellIconDownloadResult(
                     Changed: false,
                     UpToDate: true,
-                    asset.Size,
-                    asset.Sha256);
+                    remoteSize,
+                    localHash);
             }
         }
 
@@ -66,12 +82,13 @@ internal sealed class SpellIconPackageDownloadService : IDisposable
 
         try
         {
-            var downloadedHash = await DownloadAsync(
+            var (downloadedHash, downloadedSize) = await DownloadAsync(
                     asset,
                     temporaryPath,
                     progress,
                     cancellationToken);
-            if (!string.Equals(downloadedHash, asset.Sha256, StringComparison.OrdinalIgnoreCase))
+            if (asset.Sha256 is not null
+                && !string.Equals(downloadedHash, asset.Sha256, StringComparison.OrdinalIgnoreCase))
             {
                 throw new InvalidDataException(
                     $"数据包 SHA-256 校验失败：远端 {asset.Sha256}，下载结果 {downloadedHash}。");
@@ -83,8 +100,8 @@ internal sealed class SpellIconPackageDownloadService : IDisposable
             return new SpellIconDownloadResult(
                 Changed: true,
                 UpToDate: false,
-                asset.Size,
-                asset.Sha256);
+                downloadedSize,
+                downloadedHash);
         }
         finally
         {
@@ -92,23 +109,184 @@ internal sealed class SpellIconPackageDownloadService : IDisposable
         }
     }
 
-    private async Task<ReleaseAsset> GetLatestAssetAsync(CancellationToken cancellationToken)
+    private async Task<ReleaseAsset> ResolveLatestAssetAsync(
+        IProgress<SpellIconDownloadProgress>? progress,
+        CancellationToken cancellationToken)
     {
-        using var response = await _httpClient.GetAsync(
-                LatestReleaseApiUrl,
-                HttpCompletionOption.ResponseHeadersRead,
-                cancellationToken)
-            .ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+        var errors = new List<string>();
 
+        progress?.Report(new SpellIconDownloadProgress("正在读取 GitHub 最新正式版本……"));
+        if (await TryResolveAsync(
+                () => GetAssetFromApiReleaseAsync(new Uri(LatestReleaseApiUrl), cancellationToken),
+                errors,
+                cancellationToken) is { } latest)
+        {
+            return latest;
+        }
+
+        progress?.Report(new SpellIconDownloadProgress("正在改用 GitHub 发布列表……"));
+        if (await TryResolveAsync(
+                () => GetAssetFromApiReleaseListAsync(cancellationToken),
+                errors,
+                cancellationToken) is { } listed)
+        {
+            return listed;
+        }
+
+        progress?.Report(new SpellIconDownloadProgress("正在改用 GitHub 发布页直链……"));
+        if (await TryResolveAsync(
+                () => GetAssetFromBrowserDownloadAsync(new Uri(LatestBrowserDownloadUrl), cancellationToken),
+                errors,
+                cancellationToken) is { } browserLatest)
+        {
+            return browserLatest;
+        }
+
+        var versionTag = CurrentReleaseTag;
+        progress?.Report(new SpellIconDownloadProgress($"正在改用当前版本 {versionTag} 发布页……"));
+        if (await TryResolveAsync(
+                () => GetAssetFromBrowserDownloadAsync(GetCurrentVersionDownloadUri(), cancellationToken),
+                errors,
+                cancellationToken) is { } versioned)
+        {
+            return versioned;
+        }
+
+        throw new HttpRequestException(
+            "无法从 GitHub 获取技能/物品数据包。"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, errors)
+            + Environment.NewLine
+            + $"可从 {ReleasesPageUrl} 手动下载 {AssetName}。");
+    }
+
+    private static async Task<ReleaseAsset?> TryResolveAsync(
+        Func<Task<ReleaseAsset>> resolve,
+        List<string> errors,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await resolve().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            errors.Add("GitHub 请求超时。");
+            return null;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or InvalidDataException
+            or FileNotFoundException or JsonException or IOException)
+        {
+            errors.Add(ex.Message);
+            return null;
+        }
+    }
+
+    private async Task<ReleaseAsset> GetAssetFromApiReleaseAsync(
+        Uri uri,
+        CancellationToken cancellationToken)
+    {
+        using var response = await SendApiAsync(uri, cancellationToken).ConfigureAwait(false);
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken)
             .ConfigureAwait(false);
         using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
-        if (!document.RootElement.TryGetProperty("assets", out var assets)
-            || assets.ValueKind != JsonValueKind.Array)
+        if (!TryReadAssetFromRelease(document.RootElement, out var asset))
         {
-            throw new InvalidDataException("GitHub 最新正式版本没有返回 assets 列表。");
+            throw new FileNotFoundException($"GitHub 最新正式版本中找不到资产 {AssetName}。");
+        }
+
+        return asset;
+    }
+
+    private async Task<ReleaseAsset> GetAssetFromApiReleaseListAsync(CancellationToken cancellationToken)
+    {
+        using var response = await SendApiAsync(new Uri(ReleasesApiUrl), cancellationToken)
+            .ConfigureAwait(false);
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        if (document.RootElement.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidDataException("GitHub 发布列表格式无效。");
+        }
+
+        ReleaseAsset? prereleaseAsset = null;
+        foreach (var release in document.RootElement.EnumerateArray())
+        {
+            if (release.TryGetProperty("draft", out var draft) && draft.ValueKind == JsonValueKind.True)
+            {
+                continue;
+            }
+
+            if (!TryReadAssetFromRelease(release, out var asset))
+            {
+                continue;
+            }
+
+            var isPrerelease = release.TryGetProperty("prerelease", out var pre)
+                && pre.ValueKind == JsonValueKind.True;
+            if (!isPrerelease)
+            {
+                return asset;
+            }
+
+            prereleaseAsset ??= asset;
+        }
+
+        return prereleaseAsset
+            ?? throw new FileNotFoundException($"GitHub 发布列表中找不到资产 {AssetName}。");
+    }
+
+    private async Task<ReleaseAsset> GetAssetFromBrowserDownloadAsync(
+        Uri uri,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(ApiRequestTimeout);
+            using var request = new HttpRequestMessage(HttpMethod.Head, uri);
+            using var response = await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    timeoutCts.Token)
+                .ConfigureAwait(false);
+
+            if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone)
+            {
+                var url = response.RequestUri?.ToString() ?? uri.ToString();
+                throw new HttpRequestException(
+                    $"检查数据包失败：HTTP {(int)response.StatusCode} {response.ReasonPhrase}（{url}）");
+            }
+
+            if (response.IsSuccessStatusCode
+                && response.Content.Headers.ContentLength is { } size
+                && size > 0)
+            {
+                return new ReleaseAsset(uri, size, Sha256: null);
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // HEAD 超时：仍尝试正式下载该直链。
+        }
+        catch (IOException)
+        {
+            // 网络抖动：仍尝试正式下载该直链。
+        }
+
+        // 405/403 等：部分 CDN 不支持 HEAD，改由正式下载时读取 Content-Length。
+        return new ReleaseAsset(uri, Size: null, Sha256: null);
+    }
+
+    private static bool TryReadAssetFromRelease(JsonElement release, out ReleaseAsset asset)
+    {
+        asset = null!;
+        if (!release.TryGetProperty("assets", out var assets) || assets.ValueKind != JsonValueKind.Array)
+        {
+            return false;
         }
 
         foreach (var item in assets.EnumerateArray())
@@ -124,14 +302,14 @@ internal sealed class SpellIconPackageDownloadService : IDisposable
                 : null;
             if (!string.Equals(state, "uploaded", StringComparison.Ordinal))
             {
-                throw new InvalidDataException($"GitHub 资产 {AssetName} 尚未上传完成。");
+                continue;
             }
 
             if (!item.TryGetProperty("size", out var sizeElement)
                 || !sizeElement.TryGetInt64(out var size)
                 || size <= 0)
             {
-                throw new InvalidDataException($"GitHub 资产 {AssetName} 的大小无效。");
+                continue;
             }
 
             var downloadUrl = item.TryGetProperty("browser_download_url", out var urlElement)
@@ -140,49 +318,51 @@ internal sealed class SpellIconPackageDownloadService : IDisposable
             if (!Uri.TryCreate(downloadUrl, UriKind.Absolute, out var uri)
                 || !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
             {
-                throw new InvalidDataException($"GitHub 资产 {AssetName} 的下载地址无效。");
+                continue;
             }
 
-            var digest = item.TryGetProperty("digest", out var digestElement)
-                ? digestElement.GetString()
-                : null;
-            const string prefix = "sha256:";
-            if (string.IsNullOrWhiteSpace(digest)
-                || !digest.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            string? sha256 = null;
+            if (item.TryGetProperty("digest", out var digestElement))
             {
-                throw new InvalidDataException($"GitHub 资产 {AssetName} 缺少 SHA-256 digest。");
+                var digest = digestElement.GetString();
+                const string prefix = "sha256:";
+                if (!string.IsNullOrWhiteSpace(digest)
+                    && digest.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    var value = digest[prefix.Length..].Trim();
+                    if (value.Length == 64 && value.All(Uri.IsHexDigit))
+                    {
+                        sha256 = value.ToUpperInvariant();
+                    }
+                }
             }
 
-            var sha256 = digest[prefix.Length..].Trim();
-            if (sha256.Length != 64 || !sha256.All(Uri.IsHexDigit))
-            {
-                throw new InvalidDataException($"GitHub 资产 {AssetName} 的 SHA-256 digest 无效。");
-            }
-
-            return new ReleaseAsset(uri, size, sha256.ToUpperInvariant());
+            asset = new ReleaseAsset(uri, size, sha256);
+            return true;
         }
 
-        throw new FileNotFoundException($"GitHub 最新正式版本中找不到资产 {AssetName}。");
+        return false;
     }
 
-    private async Task<string> DownloadAsync(
+    private async Task<(string Sha256, long Size)> DownloadAsync(
         ReleaseAsset asset,
         string destination,
         IProgress<SpellIconDownloadProgress>? progress,
         CancellationToken cancellationToken)
     {
-        using var response = await _httpClient.GetAsync(
-                asset.DownloadUrl,
-                HttpCompletionOption.ResponseHeadersRead,
-                cancellationToken)
+        using var response = await SendDownloadAsync(HttpMethod.Get, asset.DownloadUrl, cancellationToken)
             .ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
 
-        if (response.Content.Headers.ContentLength is { } contentLength
-            && contentLength != asset.Size)
+        long? expectedSize = asset.Size;
+        if (response.Content.Headers.ContentLength is { } contentLength)
         {
-            throw new InvalidDataException(
-                $"数据包大小与 GitHub 资产信息不一致：预计 {asset.Size}，实际 {contentLength}。");
+            if (expectedSize is { } size && contentLength != size)
+            {
+                throw new InvalidDataException(
+                    $"数据包大小与 GitHub 资产信息不一致：预计 {size}，实际 {contentLength}。");
+            }
+
+            expectedSize = contentLength;
         }
 
         await using var input = await response.Content.ReadAsStreamAsync(cancellationToken)
@@ -205,30 +385,106 @@ internal sealed class SpellIconPackageDownloadService : IDisposable
             await output.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
             hash.AppendData(buffer, 0, read);
             downloaded += read;
-            if (downloaded > asset.Size)
+            if (expectedSize is { } size && downloaded > size)
             {
                 throw new InvalidDataException("下载的数据超过 GitHub 声明的资产大小。");
             }
 
-            var percentage = (int)Math.Min(100, downloaded * 100 / asset.Size);
-            if (percentage != lastPercentage)
+            if (expectedSize is { } total and > 0)
             {
-                lastPercentage = percentage;
+                var percentage = (int)Math.Min(100, downloaded * 100 / total);
+                if (percentage != lastPercentage)
+                {
+                    lastPercentage = percentage;
+                    progress?.Report(new SpellIconDownloadProgress(
+                        $"正在下载：{FormatBytes(downloaded)} / {FormatBytes(total)}",
+                        percentage));
+                }
+            }
+            else
+            {
                 progress?.Report(new SpellIconDownloadProgress(
-                    $"正在下载：{FormatBytes(downloaded)} / {FormatBytes(asset.Size)}",
-                    percentage));
+                    $"正在下载：{FormatBytes(downloaded)}"));
             }
         }
 
         await output.FlushAsync(cancellationToken).ConfigureAwait(false);
-        if (downloaded != asset.Size)
+        if (downloaded <= 0)
         {
-            throw new InvalidDataException(
-                $"数据包下载不完整：预计 {asset.Size} 字节，实际 {downloaded} 字节。");
+            throw new InvalidDataException("数据包下载结果为空。");
         }
 
-        return Convert.ToHexString(hash.GetHashAndReset());
+        if (expectedSize is { } expected && downloaded != expected)
+        {
+            throw new InvalidDataException(
+                $"数据包下载不完整：预计 {expected} 字节，实际 {downloaded} 字节。");
+        }
+
+        return (Convert.ToHexString(hash.GetHashAndReset()), downloaded);
     }
+
+    private async Task<HttpResponseMessage> SendApiAsync(Uri uri, CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(ApiRequestTimeout);
+        using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        request.Headers.TryAddWithoutValidation("X-GitHub-Api-Version", "2022-11-28");
+        var response = await _httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                timeoutCts.Token)
+            .ConfigureAwait(false);
+        EnsureSuccess(response, "读取 GitHub 版本信息");
+        return response;
+    }
+
+    private async Task<HttpResponseMessage> SendDownloadAsync(
+        HttpMethod method,
+        Uri uri,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(method, uri);
+        var response = await _httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken)
+            .ConfigureAwait(false);
+        EnsureSuccess(response, method == HttpMethod.Head ? "检查数据包" : "下载数据包");
+        return response;
+    }
+
+    private static void EnsureSuccess(HttpResponseMessage response, string action)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        using (response)
+        {
+            var url = response.RequestUri?.ToString() ?? string.Empty;
+            throw new HttpRequestException(
+                $"{action}失败：HTTP {(int)response.StatusCode} {response.ReasonPhrase}（{url}）");
+        }
+    }
+
+    internal static string CurrentReleaseTag
+    {
+        get
+        {
+            var version = typeof(SpellIconPackageDownloadService).Assembly.GetName().Version;
+            if (version is null || version.Build < 0 || version.Revision < 0)
+            {
+                return "1.2.1.19";
+            }
+
+            return $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
+        }
+    }
+
+    internal static Uri GetCurrentVersionDownloadUri() =>
+        new($"https://github.com/waynebian01/Shigure/releases/download/{CurrentReleaseTag}/{AssetName}");
 
     private static async Task<string> ComputeSha256Async(
         string path,
@@ -273,5 +529,5 @@ internal sealed class SpellIconPackageDownloadService : IDisposable
 
     public void Dispose() => _httpClient.Dispose();
 
-    private sealed record ReleaseAsset(Uri DownloadUrl, long Size, string Sha256);
+    private sealed record ReleaseAsset(Uri DownloadUrl, long? Size, string? Sha256);
 }

--- a/UI/SpellIconPackageDownloadService.cs
+++ b/UI/SpellIconPackageDownloadService.cs
@@ -155,9 +155,7 @@ internal sealed class SpellIconPackageDownloadService : IDisposable
         throw new HttpRequestException(
             "无法从 GitHub 获取技能/物品数据包。"
             + Environment.NewLine
-            + string.Join(Environment.NewLine, errors)
-            + Environment.NewLine
-            + $"可从 {ReleasesPageUrl} 手动下载 {AssetName}。");
+            + string.Join(Environment.NewLine, errors));
     }
 
     private static async Task<ReleaseAsset?> TryResolveAsync(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

设置页点击「检查更新」会弹出：

`Response status code does not indicate success: 404 (Not Found).`

原因是下载只请求 GitHub API 的 `/releases/latest`。该接口在未标记 latest，或 `api.github.com` 不可达时会直接 404；发布页 `https://github.com/waynebian01/Shigure/releases/tag/1.2.1.19` 仍可打开。

## 改动

自动下载依次尝试：

1. `GET /repos/waynebian01/Shigure/releases/latest`
2. `GET /repos/waynebian01/Shigure/releases` 发布列表
3. `https://github.com/waynebian01/Shigure/releases/latest/download/SpellIcons.shgpack`
4. 当前程序版本直链，例如 `https://github.com/waynebian01/Shigure/releases/download/1.2.1.19/SpellIcons.shgpack`

**只要自动下载失败**（含 404、超时、校验失败），弹窗都会提示到

https://github.com/waynebian01/Shigure/releases

手动下载 `SpellIcons.shgpack`，放到程序目录的 `data` 文件夹，并可选择立即打开该页面。

## 验证

- 已确认 `1.2.1.19` 含 `SpellIcons.shgpack`，`latest`、`latest/download` 与版本直链均可解析到同一文件。
- 此环境无法编译 `net10.0-windows` WinForms 工程，未在本机实际点击「检查更新」。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f803c30-19a9-45ba-8d71-8771d53099a8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f803c30-19a9-45ba-8d71-8771d53099a8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

